### PR TITLE
FEAT: Create a custom Devcontainer build

### DIFF
--- a/.devcontainer/base/Dockerfile
+++ b/.devcontainer/base/Dockerfile
@@ -1,0 +1,37 @@
+ARG DEBIAN_VARIANT=bookworm
+ARG GO_VERSION=1
+# This is probably overkill, but good learning opportunity
+FROM golang:${GO_VERSION}-${DEBIAN_VARIANT} AS preflight_builder
+
+RUN apk add --no-cache git
+WORKDIR /builds
+
+RUN GOBIN=`pwd` go get -u github.com/spectralops/preflight
+
+# Now the actual build work
+FROM debian:${DEBIAN_VARIANT}
+
+ARG NODE_VERSION=22
+ARG USERNAME=node
+
+RUN groupadd --gid 1000 ${USERNAME} \
+	&& useradd --uid 1000 --gid ${USERNAME} --shell /bin/bash --create-home ${USERNAME}
+
+USER ${USERNAME}
+
+COPY --from=preflight_builder /builds/preflight /usr/local/bin
+
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | \
+	preflight run sha256=06c0735498f1ed383a7e84d4780e73dc961285f1e7d07031f4da51a8d3f0b9be
+
+RUN nvm install ${NODE_VERSION} && nvm alias default ${NODE_VERSION}
+
+RUN corepack enable pnpm
+
+# quick smoke test
+RUN pnpm -v && node -v
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD [ "node" ]

--- a/.devcontainer/base/base-devcontainer.json
+++ b/.devcontainer/base/base-devcontainer.json
@@ -1,0 +1,36 @@
+// Base Devcontainer config
+
+// For format details, see https://aka.ms/devcontainer.json.
+{
+	"$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
+
+	"name": "DB Studio (Directus v9)",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pnpm install",
+	"features": {
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"Vue.volar",
+				"mutantdino.resourcemonitor",
+				"esbenp.prettier-vscode",
+				"github.vscode-github-actions",
+				"GitHub.vscode-pull-request-github",
+				"dbaeumer.vscode-eslint",
+				"ms-azuretools.vscode-docker"
+			]
+		}
+	}
+	// Configure tool-specific properties.
+	// "customizations": {},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/base/docker-entrypoint.sh
+++ b/.devcontainer/base/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# Run command with node if the first argument contains a "-" or is not a system command. The last
+# part inside the "{}" is a workaround for the following bug in ash/dash:
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=874264
+if [ "${1#-}" != "${1}" ] || [ -z "$(command -v "${1}")" ] || { [ -f "${1}" ] && ! [ -x "${1}" ]; }; then
+  set -- node "$@"
+fi
+
+exec "$@"

--- a/.devcontainer/base/post-create.sh
+++ b/.devcontainer/base/post-create.sh
@@ -1,0 +1,5 @@
+# uninstall any global npm packages
+npm uninstall -g tslint-to-eslint-config typescript eslint
+# Enable pnpm via corepack
+corepack enable pnpm
+pnpm install


### PR DESCRIPTION
Instead of using one of the base images use a custom build, allows for easier customization by the developer