### PR TITLE
fix(insights): Fixes an issue where nullable dates break the time series

### DIFF
--- a/app/src/panels/time-series/panel-time-series.vue
+++ b/app/src/panels/time-series/panel-time-series.vue
@@ -20,7 +20,7 @@ const props = withDefaults(
 	defineProps<{
 		height: number;
 		showHeader?: boolean;
-		data?: object[];
+		data?: Record<string, any>[]; // can we narrow the value type? I believe 
 		id: string;
 		now: Date;
 		collection: string;
@@ -118,7 +118,7 @@ function setupChart() {
 
 	const allDates = props.data.map((metric) => {
 		return toIncludeTimezoneOffset(metric.group, isFieldTimestamp);
-	});
+	}).filter((date) => !isNaN(date)); // If the year of the metric is null, the date will be NaN and break the chart
 
 	const minDate = Math.min(...allDates);
 	const maxDate = Math.max(...allDates);


### PR DESCRIPTION
`null` dates cause the conversion to a `Date` to break, returning `NaN`. `NaN` proceeds to break the x-axis.