### PR TITLE
feat(api): When creating a table in postgres, allow changing to a role

### DIFF
--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -127,6 +127,11 @@ export class CollectionsService {
 
 					const fieldsService = new FieldsService({ knex: trx, schema: this.schema });
 
+					// see if knex is connected to a postgres database, if so check if the `DB_PG_CREATE_ROLE` env variable is set and temporarily change to that role
+					if (this.knex.client === 'pg' && env['DB_PG_CREATE_ROLE']) {
+						// Using `LOCAL` to set the role for the current transaction
+						await trx.raw(`SET LOCAL ROLE "${env['DB_PG_CREATE_ROLE']}"`);
+					}
 					await trx.schema.createTable(payload.collection, (table) => {
 						for (const field of payload.fields!) {
 							if (field.type && ALIAS_TYPES.includes(field.type) === false) {


### PR DESCRIPTION
Having the application create a table with a different owner helps with situations where a shared role is desirable for multi-user access to the database. Potentially using non-DB Studio access methods (e.g. CLI, admin tools)